### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 python-sqldict
 ==============
 [![Build Status](https://travis-ci.org/RedXBeard/RomanNumbers.svg?branch=master)](https://travis-ci.org/RedXBeard/python-sqldict) 
-[![Downloads](https://pypip.in/download/sqltodict/badge.svg)](https://pypi.python.org/pypi/sqltodict/)
-[![Latest Version](https://pypip.in/version/sqltodict/badge.svg)](https://pypi.python.org/pypi/sqltodict/)
-[![Supported Python versions](https://pypip.in/py_versions/sqltodict/badge.svg)](https://pypi.python.org/pypi/sqltodict/)
-[![License](https://pypip.in/license/sqltodict/badge.svg)](https://pypi.python.org/pypi/sqltodict/)
+[![Downloads](https://img.shields.io/pypi/dm/sqltodict.svg)](https://pypi.python.org/pypi/sqltodict/)
+[![Latest Version](https://img.shields.io/pypi/v/sqltodict.svg)](https://pypi.python.org/pypi/sqltodict/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/sqltodict.svg)](https://pypi.python.org/pypi/sqltodict/)
+[![License](https://img.shields.io/pypi/l/sqltodict.svg)](https://pypi.python.org/pypi/sqltodict/)
 
 
 Raw SQL results returns as dictionary.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sqltodict))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sqltodict`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.